### PR TITLE
Add systemd service to load EFS data from a directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ prefix = /usr/local
 bindir := $(prefix)/bin
 servicedir := $(prefix)/lib/systemd/system
 
+RMTFS_EFS_PATH ?= /var/lib/rmtfs
+
 SRCS := qmi_rmtfs.c rmtfs.c rproc.c sharedmem.c storage.c util.c
 OBJS := $(SRCS:.c=.o)
 
@@ -15,13 +17,15 @@ $(OUT): $(OBJS)
 %.c: %.qmi
 	qmic -k < $<
 
-rmtfs.service: rmtfs.service.in
-	@sed 's+RMTFS_PATH+$(bindir)+g' $< > $@
+%.service: %.service.in
+	@sed -e 's+RMTFS_PATH+$(bindir)+g' -e 's+RMTFS_EFS_PATH+$(RMTFS_EFS_PATH)+g' $< > $@
 
-install: $(OUT) rmtfs.service
+install: $(OUT) rmtfs.service rmtfs-dir.service
 	@install -D -m 755 $(OUT) $(DESTDIR)$(prefix)/bin/$(OUT)
 	@install -D -m 644 rmtfs.service $(DESTDIR)$(servicedir)/rmtfs.service
+	@install -D -m 644 rmtfs-dir.service $(DESTDIR)$(servicedir)/rmtfs-dir.service
 
 clean:
 	rm -f $(OUT) $(OBJS) rmtfs.service
+	rm -f $(OUT) $(OBJS) rmtfs-dir.service
 

--- a/rmtfs-dir.service.in
+++ b/rmtfs-dir.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Qualcomm remotefs service
+Requires=qrtr-ns.service
+After=qrtr-ns.service
+
+[Service]
+ExecStart=RMTFS_PATH/rmtfs -s -o RMTFS_EFS_PATH
+Restart=always
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target

--- a/rmtfs.c
+++ b/rmtfs.c
@@ -151,11 +151,11 @@ static void rmtfs_iovec(int sock, struct qrtr_packet *pkt)
 	struct rmtfs_iovec_resp resp = {};
 	struct rmtfs_iovec_req req = {};
 	DEFINE_QRTR_PACKET(resp_buf, 256);
-	struct rmtfd *rmtfd;
+	struct rmtfd *rmtfd = NULL;
 	uint32_t caller_id = 0;
 	size_t num_entries = 0;
 	off_t sector_base;
-	uint8_t is_write;
+	uint8_t is_write = 0;
 	off_t phys_base;
 	uint8_t force = 0;
 	unsigned txn;


### PR DESCRIPTION
The EFS data can either be in a partition or a filesystem path. The rmtfs
allows both, but there is only a systemd service to use the former.

Add another systemd service that does the latter. By default, the EFS path
is /var/lib/rmtfs (which is the directory used by msm-cros-efs-loader.sh
and other tools that extract the EFS data) but this can be changed during
build by setting the RMTFS_EFS_PATH environment variable.