### PR TITLE
rmtfs.service.in: Remove dependency on qrtr-ns.service

### DIFF
--- a/rmtfs.service.in
+++ b/rmtfs.service.in
@@ -1,7 +1,5 @@
 [Unit]
 Description=Qualcomm remotefs service
-Requires=qrtr-ns.service
-After=qrtr-ns.service
 
 [Service]
 ExecStart=RMTFS_PATH/rmtfs -r -P -s


### PR DESCRIPTION
The QRTR nameserver has been built into the kernel for years now, drop the dependency since qrtr-ns.service won't do anything anyways.