### PR TITLE
rmtfs-dir.service.in: Remove dependency on qrtr-ns.service

### DIFF
--- a/rmtfs-dir.service.in
+++ b/rmtfs-dir.service.in
@@ -1,7 +1,5 @@
 [Unit]
 Description=Qualcomm remotefs service
-Requires=qrtr-ns.service
-After=qrtr-ns.service
 
 [Service]
 ExecStart=RMTFS_PATH/rmtfs -s -o RMTFS_EFS_PATH


### PR DESCRIPTION
The QRTR nameserver has been built into the kernel for years now, drop the dependency since qrtr-ns.service won't do anything anyways.