### PR TITLE
rmtfs.service: Fix start/stop ordering between rmtfs and NetworkManager

### DIFF
--- a/rmtfs-dir.service.in
+++ b/rmtfs-dir.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Qualcomm remotefs service
+Before=NetworkManager.service
 
 [Service]
 ExecStart=RMTFS_PATH/rmtfs -s -o RMTFS_EFS_PATH

--- a/rmtfs.service.in
+++ b/rmtfs.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Qualcomm remotefs service
+Before=NetworkManager.service
 
 [Service]
 ExecStart=RMTFS_PATH/rmtfs -r -P -s


### PR DESCRIPTION
Since rmtfs typically provides resources for wireless and modem-related processors, it's important to ensure that this service starts before and stops after NetworkManager.

On platforms like QCOM RB1, this sequencing prevents the Wi-Fi interface(s) from being left in a dangling state while NetworkManager attempts to tear down the interface(s):
https://github.com/qualcomm-linux/qcom-deb-images/issues/40#issuecomment-2944265370

The 'Before' dependency directive is ignored if NetworkManager is disabled or absent.